### PR TITLE
Printing each ground control point error on the report 

### DIFF
--- a/bin/plot_gcp.py
+++ b/bin/plot_gcp.py
@@ -47,7 +47,7 @@ def gcp_to_ply(gcps, reconstruction):
 
         c = 255, 0, 0
         s = "{} {} {} {} {} {}".format(
-            p[0], p[1], p[2], int(c[0]), int(c[1]), int(c[2]))
+            p.value[0], p.value[1], p.value[2], int(c[0]), int(c[1]), int(c[2]))
         vertices.append(s)
 
     header = [
@@ -96,7 +96,7 @@ def main():
             image = data.load_image(observation.shot_id)
             shot = reconstruction.shots[observation.shot_id]
 
-            reprojected = shot.project(coordinates)
+            reprojected = shot.project(coordinates.value)
             annotated = observation.projection
             rpixel = pix_coords(reprojected, image)
             apixel = pix_coords(annotated, image)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -715,8 +715,9 @@ class DataSet(DataSetBase):
         self, filename: Optional[str] = None
     ) -> pymap.TracksManager:
         """Return the tracks manager"""
-        with self.io_handler.open(self._tracks_manager_file(filename), "r") as f:
-            return pymap.TracksManager.instanciate_from_string(f.read())
+        # with self.io_handler.open(self._tracks_manager_file(filename), "r") as f:
+        #     return pymap.TracksManager.instanciate_from_string(f.read())
+        return pymap.TracksManager.instanciate_from_file(self._tracks_manager_file(filename))
 
     def tracks_exists(self, filename: Optional[str] = None) -> bool:
         return self.io_handler.isfile(self._tracks_manager_file(filename))
@@ -724,8 +725,9 @@ class DataSet(DataSetBase):
     def save_tracks_manager(
         self, tracks_manager: pymap.TracksManager, filename: Optional[str] = None
     ) -> None:
-        with self.io_handler.open(self._tracks_manager_file(filename), "w") as fw:
-            fw.write(tracks_manager.as_string())
+        #with self.io_handler.open(self._tracks_manager_file(filename), "w") as fw:
+        #    fw.write(tracks_manager.as_string())
+        tracks_manager.write_to_file(self._tracks_manager_file(filename))
 
     def _reconstruction_file(self, filename: Optional[str]) -> str:
         """Return path of reconstruction file"""
@@ -1326,15 +1328,17 @@ class UndistortedDataSet(object):
 
     def load_undistorted_tracks_manager(self) -> pymap.TracksManager:
         filename = os.path.join(self.data_path, "tracks.csv")
-        with self.io_handler.open(filename, "r") as f:
-            return pymap.TracksManager.instanciate_from_string(f.read())
+        # with self.io_handler.open(filename, "r") as f:
+        #     return pymap.TracksManager.instanciate_from_string(f.read())
+        return pymap.TracksManager.instanciate_from_file(filename)
 
     def save_undistorted_tracks_manager(
         self, tracks_manager: pymap.TracksManager
     ) -> None:
         filename = os.path.join(self.data_path, "tracks.csv")
-        with self.io_handler.open(filename, "w") as fw:
-            fw.write(tracks_manager.as_string())
+        # with self.io_handler.open(filename, "w") as fw:
+        #     fw.write(tracks_manager.as_string())
+        tracks_manager.write_to_file(filename)
 
     def load_undistorted_reconstruction(self) -> List[types.Reconstruction]:
         filename = os.path.join(self.data_path, "reconstruction.json")

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -722,7 +722,7 @@ def _read_gcp_list_lines(lines, projection, reference, exif):
                 lon, lat = easting, northing
 
             point = pymap.GroundControlPoint()
-            point.id = "unnamed-%d" % len(points)
+            point.id = "GCP-%d" % len(points)
             point.lla = {"latitude": lat, "longitude": lon, "altitude": alt}
             point.has_altitude = has_altitude
 

--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -241,15 +241,12 @@ def load_reconstruction_shots(meta_data):
         reconstruction = data.load_reconstruction()
         for index, partial_reconstruction in enumerate(reconstruction):
             key = PartialReconstruction(submodel_path, index)
-            
-            # Fix: https://github.com/mapillary/OpenSfM/pull/750
-            if sys.platform == 'win32':
-                reconstruction_shots[key] = {}
-                for shot_id in partial_reconstruction.shots:
-                    reconstruction_shots[key][shot_id] = copy.deepcopy(partial_reconstruction.shots[shot_id])
-                    reconstruction_shots[key][shot_id].metadata = partial_reconstruction.shots[shot_id].metadata
-            else:
-                reconstruction_shots[key] = partial_reconstruction.shots
+
+            # Always copy from ShotView
+            reconstruction_shots[key] = {}
+            for shot_id in partial_reconstruction.shots:
+                reconstruction_shots[key][shot_id] = copy.deepcopy(partial_reconstruction.shots[shot_id])
+                reconstruction_shots[key][shot_id].metadata = partial_reconstruction.shots[shot_id].metadata
 
 
     return reconstruction_shots

--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -8,7 +8,8 @@ import networkx as nx
 import numpy as np
 import scipy.spatial as spatial
 import vmem
-
+import copy
+import sys
 from collections import namedtuple
 from networkx.algorithms import bipartite
 from opensfm.large.lru_cache import lru_cache
@@ -240,7 +241,16 @@ def load_reconstruction_shots(meta_data):
         reconstruction = data.load_reconstruction()
         for index, partial_reconstruction in enumerate(reconstruction):
             key = PartialReconstruction(submodel_path, index)
-            reconstruction_shots[key] = partial_reconstruction.shots
+            
+            # Fix: https://github.com/mapillary/OpenSfM/pull/750
+            if sys.platform == 'win32':
+                reconstruction_shots[key] = {}
+                for shot_id in partial_reconstruction.shots:
+                    reconstruction_shots[key][shot_id] = copy.deepcopy(partial_reconstruction.shots[shot_id])
+                    reconstruction_shots[key][shot_id].metadata = partial_reconstruction.shots[shot_id].metadata
+            else:
+                reconstruction_shots[key] = partial_reconstruction.shots
+
 
     return reconstruction_shots
 

--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -402,7 +402,7 @@ void BAHelpers::AddGCPToBundle(
       const auto point_type = point.has_altitude_
                                   ? bundle::PositionConstraintType::XYZ
                                   : bundle::PositionConstraintType::XY;
-      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(), 0.1,
+      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(), 0.01,
                                point_type);
     }
 

--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -402,7 +402,7 @@ void BAHelpers::AddGCPToBundle(
       const auto point_type = point.has_altitude_
                                   ? bundle::PositionConstraintType::XYZ
                                   : bundle::PositionConstraintType::XY;
-      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(), 0.01,
+      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(), 0.02,
                                point_type);
     }
 

--- a/opensfm/stats.py
+++ b/opensfm/stats.py
@@ -250,8 +250,13 @@ def gcp_errors(data: DataSetBase, reconstructions):
             annotated = obs.projection
 
             r_pixel = features.denormalized_image_coordinates(np.array([[reprojected[0], reprojected[1]]]), shot.camera.width, shot.camera.height)[0]
-            a_pixel = features.denormalized_image_coordinates(np.array([[annotated[0], annotated[1]]]), shot.camera.width, shot.camera.height)[0]
+            r_pixel[0] /= shot.camera.width
+            r_pixel[1] /= shot.camera.height
 
+            a_pixel = features.denormalized_image_coordinates(np.array([[annotated[0], annotated[1]]]), shot.camera.width, shot.camera.height)[0]
+            a_pixel[0] /= shot.camera.width
+            a_pixel[1] /= shot.camera.height
+            
             observations.append({
                 'shot_id': obs.shot_id,
                 'annotated': list(a_pixel),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle==0.4.0
 exifread==2.1.2
 flask==1.1.2
-fpdf2==2.1.0
+fpdf2==2.2.0
 joblib==0.14.1
 matplotlib
 networkx==1.11


### PR DESCRIPTION
Displaying each GCP error helps to understand which GCP contributes maximum error. Sometimes we may mark GCP wrongly, but we could not detect which GCP causes the error. I think it is a piece of small but helpful information.